### PR TITLE
Create spxstudent.txt

### DIFF
--- a/lib/domains/org/spxstudent.txt
+++ b/lib/domains/org/spxstudent.txt
@@ -1,0 +1,1 @@
+St. Pius X Catholic High School


### PR DESCRIPTION
The notation for student e-mails at St. Pius X Catholic High School is "@spxstudent.org", however the actual domain name for the school is "spx.org".